### PR TITLE
chore: refine Renovate update policy

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  next>postcss: 8.5.16
-  minimatch@10>brace-expansion: 5.0.7
+  next>postcss: '>=8.5.10'
 
 importers:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,11 +3,9 @@ packages:
 
 minimumReleaseAge: 4320
 
+# Next.js 16 bundles a vulnerable PostCSS release; keep its transitive dependency patched.
 overrides:
-  # Temporary security override for GHSA-qx2v-qp2m-jg93.
-  "next>postcss": "8.5.16"
-  # Keep installs compatible with minimumReleaseAge until brace-expansion 5.0.7 ages in.
-  "minimatch@10>brace-expansion": "5.0.7"
+  "next>postcss": ">=8.5.10"
 
 allowBuilds:
   sharp: true

--- a/renovate.json
+++ b/renovate.json
@@ -16,18 +16,21 @@
       "groupName": "other non-major dependencies",
       "groupSlug": "other-minor-patch"
     },
+    // Next.js 17 requires a dedicated migration and compatibility review.
     {
       "matchPackageNames": ["next", "@next/bundle-analyzer"],
       "groupName": "Next.js",
       "groupSlug": "nextjs",
       "allowedVersions": "<17.0.0"
     },
+    // React 20 requires a dedicated migration and compatibility review.
     {
       "matchPackageNames": ["react", "react-dom"],
       "groupName": "React",
       "groupSlug": "react",
       "allowedVersions": "<20.0.0"
     },
+    // ESLint 10 currently breaks linting with eslint-plugin-react 7.37.5.
     {
       "matchPackageNames": ["eslint"],
       "allowedVersions": "<10.0.0"
@@ -48,6 +51,7 @@
       "groupName": "linting and TypeScript",
       "groupSlug": "linting-typescript"
     },
+    // Tailwind CSS 4 needs a separate migration after the previous Vercel build failure.
     {
       "matchPackageNames": ["tailwindcss", "postcss", "autoprefixer", "@tailwindcss/typography"],
       "groupName": "Tailwind CSS",


### PR DESCRIPTION
## 变更内容
- 移除已过期的 brace-expansion 临时锁定
- 将 Next.js 的 PostCSS 安全覆盖改为 >=8.5.10
- 记录 Next、React、ESLint 与 Tailwind 的大版本人工闸门原因

## 验证
- CI=true pnpm install --frozen-lockfile --ignore-scripts
- pnpm check
- pnpm audit --prod

ESLint 10 已在隔离环境验证，会与 eslint-plugin-react 7.37.5 不兼容并导致 lint 失败，因此继续限制在 ESLint 9。